### PR TITLE
Add attributes to ASN entities that have no metadata

### DIFF
--- a/src/Controller/EntitiesController.php
+++ b/src/Controller/EntitiesController.php
@@ -244,6 +244,8 @@ class EntitiesController extends ApiController
             $defaultAsn->setName(sprintf("AS%d", $entityCode));
             $defaultAsn->setId(1001);
             $defaultAsn->setType($defaultAsnMetatype);
+            $defaultAsn->setFQID(sprintf("asn.%d", $entityCode));
+            $defaultAsn->setIpCount(0);
 
             $entity = [$defaultAsn];
         }

--- a/src/Entity/MetadataEntity.php
+++ b/src/Entity/MetadataEntity.php
@@ -220,6 +220,22 @@ class MetadataEntity
         }
     }
 
+    public function setFQID(string $fqid)
+    {
+        $attr = new MetadataEntityAttribute();
+        $attr->setKey("fqid");
+        $attr->setValue($fqid);
+        $this->attributes->add($attr);  // XXX what if FQID already exists?
+    }
+
+    public function setIpCount(int $count)
+    {
+        $attr = new MetadataEntityAttribute();
+        $attr->setKey("ip_count");
+        $attr->setValue($count);
+        $this->attributes->add($attr);  // XXX what if count already exists?
+    }
+
     /**
      * Get relationships
      *


### PR DESCRIPTION
Attributes supported: fqid and ip_count (set to 0)

Some portions of our UI expect these attributes to exist for any ASN entity.