### PR TITLE
Add support for querying GTR data to the IODA API

### DIFF
--- a/src/Controller/DatasourcesController.php
+++ b/src/Controller/DatasourcesController.php
@@ -128,6 +128,13 @@ class DatasourcesController extends ApiController
      *     </li>
      * </ul>
      *
+     * <h3>Google Transparency Report (gtr)</h3>
+     * <ul>
+     *     <li>
+     *          Data published by the Google Transparency Report team that provide a normalised indication of the amount of traffic observed for each of Google's public services (e.g. search, maps, drive, translate etc.) for a particular country.
+     *     </li>
+     * </ul>
+     *
      * @Route("/", methods={"GET"}, name="getall")
      * @SWG\Tag(name="Data Sources")
      * @SWG\Response(

--- a/src/Controller/SignalsController.php
+++ b/src/Controller/SignalsController.php
@@ -165,6 +165,14 @@ class SignalsController extends ApiController
      *     default=null
      * )
      * @SWG\Parameter(
+     *     name="sourceParams",
+     *     in="query",
+     *     type="string",
+     *     description="Comma-separated list of additional datasource-specific parameters",
+     *     required=false,
+     *     default=null
+     * )
+     * @SWG\Parameter(
      *     name="maxPoints",
      *     in="query",
      *     type="integer",
@@ -254,6 +262,7 @@ class SignalsController extends ApiController
                                 new RequestParameter('from', RequestParameter::INTEGER, null, true),
                                 new RequestParameter('until', RequestParameter::INTEGER, null, true),
                                 new RequestParameter('datasource', RequestParameter::STRING, null, false),
+                                new RequestParameter('sourceParams', RequestParameter::STRING, null, false),
                                 new RequestParameter('maxPoints', RequestParameter::INTEGER, null, false),
                             ],
                             $request
@@ -266,7 +275,8 @@ class SignalsController extends ApiController
         $from = $env->getParam('from');
         $until = $env->getParam('until');
         $datasource_str = $env->getParam('datasource');
-        $maxPoints = $env->getParam('maxPoints');
+	$maxPoints = $env->getParam('maxPoints');
+	$extraParams = $env->getParam('sourceParams');
         $metas = $this->metadataService->search($entityType, $entityCode);
 
         /* Mildly dirty hack added by Shane to provide a "default"
@@ -314,7 +324,7 @@ class SignalsController extends ApiController
         $ts_sets = [];
         $perf = null;
         try{
-            [$ts_sets, $perf] = $this->signalsService->queryForAll($from, $until, $entities, $datasource_array, $maxPoints);
+            [$ts_sets, $perf] = $this->signalsService->queryForAll($from, $until, $entities, $datasource_array, $maxPoints, $extraParams);
         } catch (BackendException $ex) {
             $env->setError($ex->getMessage());
         }

--- a/src/Service/InfluxService.php
+++ b/src/Service/InfluxService.php
@@ -193,8 +193,43 @@ class InfluxService
             "datasource_id" => 1,
             "field" => "uniq_src_ip",
             "bucket" => "ioda_merit_nt_non_erratic",
+        ],
+        "gtr" => [
+            "country" => [
+                "measurement" => "google_tr",
+                "code_field" => "country_code",
+                "extra" => " and r.product == \"WEB_SEARCH\"",
+                "aggr" => "|> group() |> aggregateWindow(every: 30m, fn:sum) ",
+            ],
+            "datasource_id" => 1,
+            "field" => "traffic",
+            "bucket" => "ioda_gtr",
         ]
     ];
+
+    private function generateGTRProductClause(?string $params) {
+        if ($params == null) {
+            return " and r.product == \"WEB_SEARCH\"";
+        }
+        $products = explode(",", $params);
+        if (count($products) == 0) {
+            return " and r.product == \"WEB_SEARCH\"";
+        }
+
+        $clause = " and ( ";
+        foreach($products as $p) {
+            $p = strtoupper($p);
+            if ($p == "SEARCH") {
+                $p = "WEB_SEARCH";
+            } else if ($p == "MAIL") {
+                $p = "GMAIL";
+            }
+            $clause .= "r.product == \"$p\" or ";
+        }
+        $clause = substr($clause, 0, -3);
+        $clause .= ") ";
+        return $clause;
+    }
 
     /**
      * Build Flux query for BGP data source.
@@ -203,15 +238,37 @@ class InfluxService
      * @param string $entityCode
      * @return array|string|string[]
      */
-    public function buildFluxQuery(string $datasource, array $entities, QueryTime $from, QueryTime $until, int $step)
+    public function buildFluxQuery(string $datasource, array $entities, QueryTime $from, QueryTime $until, int $step, ?string $extraParams)
     {
+        $from_ts = $from->getEpochTime()*1000;
+        $until_ts = $until->getEpochTime()*1000;
+
+        $query = <<<END
+{
+  "queries": [
+  ],
+  "from": "$from_ts",
+  "to": "$until_ts"
+}
+END;
+        if (count($entities) == 0) {
+            return $query;
+        }
+
         $entityType = $entities[0]->getType()->getType();
+        if (! array_key_exists($entityType, self::FIELD_MAP[$datasource]) ) {
+            return $query;
+        }
 
         $field = self::FIELD_MAP[$datasource]["field"];
         $code_field =  self::FIELD_MAP[$datasource]["$entityType"]["code_field"];
         $measurement = self::FIELD_MAP[$datasource]["$entityType"]["measurement"];
         $bucket = self::FIELD_MAP[$datasource]["bucket"];
-        $extra = self::FIELD_MAP[$datasource]["$entityType"]["extra"];
+        if ($datasource == "gtr" && $extraParams != null) {
+            $extra = $this->generateGTRProductClause($extraParams);
+        } else {
+            $extra = self::FIELD_MAP[$datasource]["$entityType"]["extra"];
+        }
         $aggr = self::FIELD_MAP[$datasource]["$entityType"]["aggr"];
 
         $datasource_id = self::FIELD_MAP[$datasource]["datasource_id"];
@@ -254,8 +311,6 @@ END;
 
         $combined_queries = implode(",", $queries);
 
-        $from_ts = $from->getEpochTime()*1000;
-        $until_ts = $until->getEpochTime()*1000;
 
         $query = <<<END
 {

--- a/src/Service/SignalsService.php
+++ b/src/Service/SignalsService.php
@@ -254,10 +254,11 @@ class SignalsService
      * @param array $entities
      * @param array $datasources
      * @param int|null $maxPoints
+     * @param string|null $extraParams
      * @return array
      * @throws BackendException
      */
-    public function queryForAll(QueryTime $from, QueryTime $until, array $entities, array $datasources, ?int $maxPoints): array
+    public function queryForAll(QueryTime $from, QueryTime $until, array $entities, array $datasources, ?int $maxPoints, ?string $extraParams): array
     {
         $ts_array = [];
 
@@ -275,7 +276,8 @@ class SignalsService
 
             $step = $this->calculateStep($from, $until, $maxPoints, $datasource->getNativeStep());
             $from = $this->roundDownFromTs($from, $step);
-            $arr = $this->queryForInfluxV2($ds, $entities, $from, $until, $step);
+            $arr = $this->queryForInfluxV2($ds, $entities, $from, $until, $step,
+                        $extraParams);
 
             $perf[] = [
                 "datasource"=>$ds,
@@ -338,9 +340,9 @@ class SignalsService
     /**
      * @throws BackendException
      */
-    public function queryForInfluxV2(string $datasource, array $entities, QueryTime $from, QueryTime $until, int $step): array
+    public function queryForInfluxV2(string $datasource, array $entities, QueryTime $from, QueryTime $until, int $step, ?string $extraParam): array
     {
-        $query = $this->influxService->buildFluxQuery($datasource, $entities, $from, $until, $step);
+        $query = $this->influxService->buildFluxQuery($datasource, $entities, $from, $until, $step, $extraParam);
         return $this -> influxV2Backend -> queryInfluxV2($query);
     }
 }

--- a/src/TimeSeries/Backend/InfluxV2Backend.php
+++ b/src/TimeSeries/Backend/InfluxV2Backend.php
@@ -80,7 +80,10 @@ class InfluxV2Backend
     }
 
     private function parseReturnValue($responseJson) {
-        $res_array = [];
+	$res_array = [];
+        if (!array_key_exists("results", $responseJson)) {
+	    return $res_array;
+	}
         foreach($responseJson["results"] as $entityCode => $res) {
             $raw_values = $res["frames"][0]["data"]["values"];
             if(count($raw_values)!=2){


### PR DESCRIPTION
Adds extra query parameter for raw signal data: "sourceParams", which can be used for providing additional datasource-specific query parameters (e.g. the product(s) to query for GTR data).