### PR TITLE
Add ability to split the time period for a signal into eras

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -10,7 +10,7 @@ doctrine:
         connections:
           ioda_db:
             driver: 'pdo_mysql'
-            server_version: '9.4'
+            server_version: '14.4'
             url: '%env(resolve:DATABASE_ALERTS_URL)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'

--- a/src/Entity/DataEraEntity.php
+++ b/src/Entity/DataEraEntity.php
@@ -1,0 +1,284 @@
+<?php
+/*
+ * This source code is Copyright (c) 2024 Georgia Tech Research
+ * Corporation. All Rights Reserved. Permission to copy, modify, and distribute
+ * this software and its documentation for academic research and education
+ * purposes, without fee, and without a written agreement is hereby granted,
+ * provided that the above copyright notice, this paragraph and the following
+ * three paragraphs appear in all copies. Permission to make use of this
+ * software for other than academic research and education purposes may be
+ * obtained by contacting:
+ *
+ *  Office of Technology Licensing
+ *  Georgia Institute of Technology
+ *  926 Dalney Street, NW
+ *  Atlanta, GA 30318
+ *  404.385.8066
+ *  techlicensing@gtrc.gatech.edu
+ *
+ * This software program and documentation are copyrighted by Georgia Tech
+ * Research Corporation (GTRC). The software program and documentation are
+ * supplied "as is", without any accompanying services from GTRC. GTRC does
+ * not warrant that the operation of the program will be uninterrupted or
+ * error-free. The end-user understands that the program was developed for
+ * research purposes and is advised not to rely exclusively on the program for
+ * any reason.
+ *
+ * IN NO EVENT SHALL GEORGIA TECH RESEARCH CORPORATION BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF GEORGIA TECH RESEARCH CORPORATION HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE. GEORGIA TECH RESEARCH CORPORATION SPECIFICALLY DISCLAIMS ANY
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+ * HEREUNDER IS ON AN "AS IS" BASIS, AND  GEORGIA TECH RESEARCH CORPORATION HAS
+ * NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ *
+ * This source code is part of the IODA software. The original IODA software
+ * is Copyright (c) 2013 The Regents of the University of California. All rights
+ * reserved. Permission to copy, modify, and distribute this software for
+ * academic research and education purposes is subject to the conditions and
+ * copyright notices in the source code files and in the included LICENSE file.
+ */
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\DataErasRepository")
+ * @ORM\Table(name="ioda_data_eras")
+ */
+class DataEraEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @var integer
+     */
+    private $era_id;
+
+    /**
+     * @ORM\Column(type="string")
+     * @ORM\Id
+     * @var string
+     */
+    private $datasource;
+
+    /**
+     * @ORM\Column(type="string")
+     * @ORM\Id
+     * @var string
+     */
+    private $entity_type;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $query_term;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $bucket;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @var integer
+     */
+    private $grafanasource;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @var integer
+     */
+    private $start_ts;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @var integer
+     */
+    private $end_ts;
+
+    public function __construct() {
+
+    }
+
+    /**
+     * @return int
+     */
+    public function getEraId(): int
+    {
+        return $this->era_id;
+    }
+
+    /**
+     * @param int $id
+     * @return DataEraEntity
+     */
+    public function setEraId(int $id): DataEraEntity
+    {
+        $this->era_id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDatasource(): string
+    {
+        return $this->datasource;
+    }
+
+    /**
+     * @param string $source
+     * @return DataEraEntity
+     */
+    public function setDatasource(string $source): DataEraEntity
+    {
+        $this->datasource = $source;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityType(): string
+    {
+        return $this->entity_type;
+    }
+
+    /**
+     * @param string $type
+     * @return DataEraEntity
+     */
+    public function setEntityType(string $type): DataEraEntity
+    {
+        $this->entity_type = $type;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getQueryTerm(): string
+    {
+        if ($this->query_term) {
+            return str_replace("@", "\"", $this->query_term);
+        }
+        return "";
+    }
+
+    /**
+     * @param string $term
+     * @return DataEraEntity
+     */
+    public function setQueryTerm(string $term): DataEraEntity
+    {
+        $this->query_term = $term;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBucket(): string
+    {
+        return $this->bucket;
+    }
+
+    /**
+     * @param string $bucket
+     * @return DataEraEntity
+     */
+    public function setBucket(string $bucket): DataEraEntity
+    {
+        $this->bucket = $bucket;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * @param string $field
+     * @return DataEraEntity
+     */
+    public function setField(string $field): DataEraEntity
+    {
+        $this->field = $field;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getGrafanaSource(): int
+    {
+        return $this->grafanasource;
+    }
+
+    /**
+     * @param int $source
+     * @return DataEraEntity
+     */
+    public function setGrafanaSource(int $source): DataEraEntity
+    {
+        $this->grafanasource = $source;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStartTime(): int
+    {
+        return $this->start_ts;
+    }
+
+    /**
+     * @param int $start
+     * @return DataEraEntity
+     */
+    public function setStartTime(int $start): DataEraEntity
+    {
+        $this->start_ts = $start;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEndTime(): int
+    {
+        if (! $this->end_ts || $this->end_ts <= 0) {
+            return time() + 86400;
+        }
+        return $this->end_ts;
+    }
+
+    /**
+     * @param int $end
+     * @return DataEraEntity
+     */
+    public function setEndTime(int $end): DataEraEntity
+    {
+        $this->end_ts = $end;
+        return $this;
+    }
+}

--- a/src/Repository/DataErasRepository.php
+++ b/src/Repository/DataErasRepository.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * This source code is Copyright (c) 2024 Georgia Tech Research
+ * Corporation. All Rights Reserved. Permission to copy, modify, and distribute
+ * this software and its documentation for academic research and education
+ * purposes, without fee, and without a written agreement is hereby granted,
+ * provided that the above copyright notice, this paragraph and the following
+ * three paragraphs appear in all copies. Permission to make use of this
+ * software for other than academic research and education purposes may be
+ * obtained by contacting:
+ *
+ *  Office of Technology Licensing
+ *  Georgia Institute of Technology
+ *  926 Dalney Street, NW
+ *  Atlanta, GA 30318
+ *  404.385.8066
+ *  techlicensing@gtrc.gatech.edu
+ *
+ * This software program and documentation are copyrighted by Georgia Tech
+ * Research Corporation (GTRC). The software program and documentation are
+ * supplied "as is", without any accompanying services from GTRC. GTRC does
+ * not warrant that the operation of the program will be uninterrupted or
+ * error-free. The end-user understands that the program was developed for
+ * research purposes and is advised not to rely exclusively on the program for
+ * any reason.
+ *
+ * IN NO EVENT SHALL GEORGIA TECH RESEARCH CORPORATION BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF GEORGIA TECH RESEARCH CORPORATION HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE. GEORGIA TECH RESEARCH CORPORATION SPECIFICALLY DISCLAIMS ANY
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+ * HEREUNDER IS ON AN "AS IS" BASIS, AND  GEORGIA TECH RESEARCH CORPORATION HAS
+ * NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ *
+ * This source code is part of the IODA software. The original IODA software
+ * is Copyright (c) 2013 The Regents of the University of California. All rights
+ * reserved. Permission to copy, modify, and distribute this software for
+ * academic research and education purposes is subject to the conditions and
+ * copyright notices in the source code files and in the included LICENSE file.
+ */
+
+namespace App\Repository;
+
+use App\Entity\DataEraEntity;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class DataErasRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DataEraEntity::class);
+    }
+
+    public function findErasForTimeRange($datasource, $entitytype,
+            $from, $until)
+    {
+        $em = $this->getEntityManager();
+        $rsm = new ResultSetMappingBuilder($em, ResultSetMappingBuilder::COLUMN_RENAMING_INCREMENT);
+        $rsm->addRootEntityFromClassMetadata('App\Entity\DataEraEntity', 'era');
+
+        if ($from <= 0) {
+            return [];
+        }
+
+        $sql =
+            'SELECT ' . $rsm->generateSelectClause() . '
+            FROM ioda_data_eras era
+            WHERE
+                LOWER(era.datasource) = LOWER(:datasource) AND
+                LOWER(era.entity_type) = LOWER(:entitytype) AND
+                era.start_ts != 0 AND
+                era.dev_flag = FALSE AND
+                (
+                  (era.start_ts <= :from AND (era.end_ts > :from OR era.end_ts < 0)) OR
+                  (era.start_ts < :end AND (era.end_ts > :end OR era.end_ts < 0)) OR
+                  (era.start_ts <= :from AND era.end_ts > :end)
+                ) ORDER BY era.start_ts '
+        ;
+
+        $q = $em->createNativeQuery($sql, $rsm)->setParameters([
+                'datasource' => $datasource,
+                'entitytype' => $entitytype,
+                'from' => $from,
+                'end' => $until,
+             ]);
+        $res = $q->getResult();
+
+        return $res;
+    }
+}
+

--- a/src/Service/DataErasService.php
+++ b/src/Service/DataErasService.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * This source code is Copyright (c) 2024 Georgia Tech Research
+ * Corporation. All Rights Reserved. Permission to copy, modify, and distribute
+ * this software and its documentation for academic research and education
+ * purposes, without fee, and without a written agreement is hereby granted,
+ * provided that the above copyright notice, this paragraph and the following
+ * three paragraphs appear in all copies. Permission to make use of this
+ * software for other than academic research and education purposes may be
+ * obtained by contacting:
+ *
+ *  Office of Technology Licensing
+ *  Georgia Institute of Technology
+ *  926 Dalney Street, NW
+ *  Atlanta, GA 30318
+ *  404.385.8066
+ *  techlicensing@gtrc.gatech.edu
+ *
+ * This software program and documentation are copyrighted by Georgia Tech
+ * Research Corporation (GTRC). The software program and documentation are
+ * supplied "as is", without any accompanying services from GTRC. GTRC does
+ * not warrant that the operation of the program will be uninterrupted or
+ * error-free. The end-user understands that the program was developed for
+ * research purposes and is advised not to rely exclusively on the program for
+ * any reason.
+ *
+ * IN NO EVENT SHALL GEORGIA TECH RESEARCH CORPORATION BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF GEORGIA TECH RESEARCH CORPORATION HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE. GEORGIA TECH RESEARCH CORPORATION SPECIFICALLY DISCLAIMS ANY
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+ * HEREUNDER IS ON AN "AS IS" BASIS, AND  GEORGIA TECH RESEARCH CORPORATION HAS
+ * NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ *
+ * This source code is part of the IODA software. The original IODA software
+ * is Copyright (c) 2013 The Regents of the University of California. All rights
+ * reserved. Permission to copy, modify, and distribute this software for
+ * academic research and education purposes is subject to the conditions and
+ * copyright notices in the source code files and in the included LICENSE file.
+ */
+
+namespace App\Service;
+
+use App\Entity\DataEraEntity;
+use App\Repository\DataErasRepository;
+
+class DataErasService {
+    private $repo;
+
+    public function __construct(DataErasRepository $erasRepo)
+    {
+        $this->repo = $erasRepo;
+    }
+
+    public function getEras($datasource, $entitytype, $from, $until)
+    {
+        return $this->repo->findErasForTimeRange($datasource,
+                $entitytype, $from, $until);
+    }
+}
+

--- a/src/TimeSeries/TimeSeries.php
+++ b/src/TimeSeries/TimeSeries.php
@@ -299,6 +299,17 @@ class TimeSeries
         $this->values[] = $value;
     }
 
+    /**
+     * Extend an existing timeseries with additional values
+     *
+     * @param int[] $values -- the values to add to the existing array
+     *
+     */
+    public function appendValues(array $values): void
+    {
+        $this->values = array_merge($this->values, $values);
+    }
+
     public function getNumPoints(): int
     {
         return count($this->values);


### PR DESCRIPTION
Different eras may have different query parameters (e.g. using a different geo-location provider, or querying from a different measurement or datasource). The exact timestamps that bound an era can be different for each datasource (i.e. we switched over BGP to a new era on a particular day, but did not make a corresponding change to AP until 2 weeks later).

The main aim of this work is to transparently handle queries that span significant changes in the data collection process.