### PR TITLE
Update to use NE 5.1 topojson for /topo requests

### DIFF
--- a/src/Controller/TopoController.php
+++ b/src/Controller/TopoController.php
@@ -103,12 +103,14 @@ class TopoController extends ApiController
      * @var Request $request
      * @var SerializerInterface $serializer
      * @var TopoService $topoService
-     * @return JsonResponse
+     * @return BinaryFileResponse
      */
     public function topoLookup(string $entityType, Request $request,
                           SerializerInterface $serializer,
                           TopoService $topoService)
     {
+	    return $topoService->getTopoJson($entityType);
+	    /*
         $env = new Envelope('topo.get',
             'query',
             [],
@@ -127,6 +129,7 @@ class TopoController extends ApiController
             $env->setError($ex->getMessage());
             return $this->json($env, 400);
         }
-        return $this->json($env);
+	return $this->json($env);
+	     */
     }
 }


### PR DESCRIPTION
We now send topojson as binary file directly rather than parsing and adding an envelope, which is slow and takes a ton of memory.

Note that the pre-processing phase will embed an envelope in the topojson file, so clients receive the data in the format that they expect. The API no longer needs to generate the envelope itself.